### PR TITLE
Use OTP Token when pushing gems to rubygems.org

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,10 @@ jobs:
           touch $HOME/.gem/credentials
           chmod 0600 $HOME/.gem/credentials
           printf -- "---\n:rubygems_api_key: ${GEM_HOST_API_KEY}\n" > $HOME/.gem/credentials
-          gem push ./build/gems/*.gem
+          # TODO: If it is possible to accept input in the middle of a step, then the OTP Token should be inputted instead of generated.
+          gem install rotp -v 6.2.0
+          OTP_TOKEN=$(ruby -rtime -rrotp -e "puts ROTP::TOTP.new('${OTP_SECRET}', issuer: 'rubygems.org').at(Time.now)")
+          gem push --otp="${OTP_TOKEN}" ./build/gems/*.gem
         env:
           GEM_HOST_API_KEY: "${{secrets.RUBYGEMS_API_KEY}}"
+          OTP_SECRET: "${{secrets.RUBYGEMS_OTP_SECRET}}"


### PR DESCRIPTION
* c71630a Use OTP Token when pushing gems to rubygems.org