### PR TITLE
Fix a date format bug.

### DIFF
--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -172,7 +172,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     String f =
         String.format(
             Locale.ENGLISH,
-            "%02d-%02d-%02d",
+            "%04d-%02d-%02d",
             cal.get(Calendar.YEAR),
             cal.get(Calendar.MONTH) + 1,
             cal.get(Calendar.DAY_OF_MONTH));


### PR DESCRIPTION
* `setSqlDate` should use the format `%04d-%02d-%02d` instead of `%02d-%02d-%02d`.

![image](https://user-images.githubusercontent.com/4525500/133254209-3cc28725-76d4-468a-a3ff-fccf855ccd62.png)

This bug was introduced during #14.