### PR TITLE
Fix SnowflakeOutputPlugin location

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,7 +50,7 @@ dependencies {
     compile "net.snowflake:snowflake-jdbc:3.13.5"
 }
 embulkPlugin {
-    mainClass = "org.embulk.output.snowflake.SnowflakeOutputPlugin"
+    mainClass = "org.embulk.output.SnowflakeOutputPlugin"
     category = "output"
     type = "snowflake"
 }


### PR DESCRIPTION
* The location of the Plugin class that should be specified in `build.gradle` was wrong, so it has been fixed.