### PR TITLE
set CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX=true

### DIFF
--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -88,6 +88,13 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     props.setProperty("db", t.getDatabase());
     props.setProperty("schema", t.getSchema());
 
+    // When CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX is false (default),
+    // getMetaData().getColumns() returns columns of the tables which table name is
+    // same in all databases.
+    // So, set this parameter true.
+    // https://github.com/snowflakedb/snowflake-jdbc/blob/032bdceb408ebeedb1a9ad4edd9ee6cf7c6bb470/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java#L1261-L1269
+    props.setProperty("CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX", "true");
+
     props.putAll(t.getOptions());
 
     logConnectionProperties(url, props);
@@ -135,8 +142,7 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     SnowflakePluginTask t = (SnowflakePluginTask) task;
     // TODO: put some where executes once
     if (this.stageIdentifier == null) {
-      SnowflakeOutputConnection snowflakeCon =
-          (SnowflakeOutputConnection) getConnector(task, true).connect(true);
+      SnowflakeOutputConnection snowflakeCon = (SnowflakeOutputConnection) getConnector(task, true).connect(true);
       this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(t);
       snowflakeCon.runCreateStage(this.stageIdentifier);
     }


### PR DESCRIPTION
When database and schema is null, `getColumns()` searches all columns of all databases.

This causes a bug like below.
When mode is INSERT, create temporary table first and its schema is calculated by DatabaseMetaData `getColumns()`.
When the table of same name exists across some databases, temporary table schema consists of all of the tables' columns.

---

Why this problem occurs, and how I fixed it.

1.` embulk-output-jdbc` call `getColumns()` to fetch table columns [[code](https://github.com/embulk/embulk-output-jdbc/blob/89a63aabee57e4bc105538a639e68c3243465fc0/embulk-output-jdbc/src/main/java/org/embulk/output/jdbc/AbstractJdbcOutputPlugin.java#L1002-L1006)]
2. In this case, `table.getDatabase()` and `table.getSchema()` are null.
3. when databse and schema are null, `snowflake-jdbc` searches all columns in account [[code](https://github.com/snowflakedb/snowflake-jdbc/blob/032bdceb408ebeedb1a9ad4edd9ee6cf7c6bb470/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java#L1575-L1585)]
4. but,`CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX` is true, session context's database/schema is used to search columns. [[code](https://github.com/snowflakedb/snowflake-jdbc/blob/032bdceb408ebeedb1a9ad4edd9ee6cf7c6bb470/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java#L1261-L1269)]