### PR TITLE
複数クエリの許可設定を追加

### DIFF
--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -94,6 +94,7 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     // So, set this parameter true.
     // https://github.com/snowflakedb/snowflake-jdbc/blob/032bdceb408ebeedb1a9ad4edd9ee6cf7c6bb470/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java#L1261-L1269
     props.setProperty("CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX", "true");
+    props.setProperty("MULTI_STATEMENT_COUNT", "0");
 
     props.putAll(t.getOptions());
 

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -136,6 +136,24 @@ public class TestSnowflakeOutputPlugin {
     }
   }
 
+  // insert／update／delete
+  private void runUpdateQuery(String query) {
+    // load driver
+    try {
+      Class.forName("net.snowflake.client.jdbc.SnowflakeDriver");
+    } catch (ClassNotFoundException e) {
+      throw new RuntimeException(e);
+    }
+    String uri = String.format("jdbc:snowflake://%s", TEST_PROPERTIES.getProperty("host"));
+    try (Connection conn = DriverManager.getConnection(uri, TEST_PROPERTIES);
+         Statement stmt = conn.createStatement()
+    ) {
+      stmt.executeUpdate(query);
+    } catch (SQLException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private ThrowableConsumer<ResultSet> foreachResult(ThrowableConsumer<ResultSet> f) {
     return rs -> {
       try {
@@ -331,14 +349,13 @@ public class TestSnowflakeOutputPlugin {
     config.set("table", temporaryTableName);
     embulk.runOutput(config, in.toPath());
 
-    runQuery(
+    runUpdateQuery(
             String.format(
-                    "insert into %s SELECT * FROM %s; DROP TABLE %s;",
+                    "insert into %s select * from %s; drop table %s;",
                     targetTableFullName,
                     temporaryTableFullName,
                     temporaryTableFullName
-            ),
-            foreachResult(rs_ -> {})
+            )
     );
   }
 

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -342,7 +342,6 @@ public class TestSnowflakeOutputPlugin {
                     .set("schema", TEST_SNOWFLAKE_SCHEMA)
                     .set("mode", "replace")
                     .set("table", targetTableName)
-                    .set("MULTI_STATEMENT_COUNT", "0")
             ;
     embulk.runOutput(config, in.toPath());
 

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -136,23 +136,6 @@ public class TestSnowflakeOutputPlugin {
     }
   }
 
-  // insert／update／delete
-  private void runUpdateQuery(String query) {
-    // load driver
-    try {
-      Class.forName("net.snowflake.client.jdbc.SnowflakeDriver");
-    } catch (ClassNotFoundException e) {
-      throw new RuntimeException(e);
-    }
-    String uri = String.format("jdbc:snowflake://%s", TEST_PROPERTIES.getProperty("host"));
-    try (Connection conn = DriverManager.getConnection(uri, TEST_PROPERTIES);
-        Statement stmt = conn.createStatement()) {
-      stmt.executeUpdate(query);
-    } catch (SQLException e) {
-      throw new RuntimeException(e);
-    }
-  }
-
   private ThrowableConsumer<ResultSet> foreachResult(ThrowableConsumer<ResultSet> f) {
     return rs -> {
       try {

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -357,6 +357,16 @@ public class TestSnowflakeOutputPlugin {
                     temporaryTableFullName
             )
     );
+
+    runQuery(
+            String.format(
+                    "select count(*) from %s;",
+                    targetTableFullName
+            ),
+            foreachResult(rs -> {
+              assertEquals(6, rs.getInt(1));
+            })
+    );
   }
 
   @Test

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -146,8 +146,7 @@ public class TestSnowflakeOutputPlugin {
     }
     String uri = String.format("jdbc:snowflake://%s", TEST_PROPERTIES.getProperty("host"));
     try (Connection conn = DriverManager.getConnection(uri, TEST_PROPERTIES);
-         Statement stmt = conn.createStatement()
-    ) {
+        Statement stmt = conn.createStatement()) {
       stmt.executeUpdate(query);
     } catch (SQLException e) {
       throw new RuntimeException(e);
@@ -310,62 +309,54 @@ public class TestSnowflakeOutputPlugin {
   public void testExecuteMultiQuery() throws IOException {
     File in = testFolder.newFile(SnowflakeUtils.randomString(8) + ".csv");
     List<String> lines =
-            Stream.of("c0:double, c1:string", "0.0,aaa", "0.1,bbb", "1.2,ccc")
-                    .collect(Collectors.toList());
+        Stream.of("c0:double, c1:string", "0.0,aaa", "0.1,bbb", "1.2,ccc")
+            .collect(Collectors.toList());
     Files.write(in.toPath(), lines);
 
     String targetTableName = generateTemporaryTableName();
     String targetTableFullName =
-            String.format("\"%s\".\"%s\".\"%s\"", TEST_SNOWFLAKE_DB, TEST_SNOWFLAKE_SCHEMA, targetTableName);
+        String.format(
+            "\"%s\".\"%s\".\"%s\"", TEST_SNOWFLAKE_DB, TEST_SNOWFLAKE_SCHEMA, targetTableName);
     runQuery(
-            String.format("create table %s (c0 FLOAT, c1 STRING)", targetTableFullName),
-            foreachResult(rs_ -> {})
-    );
+        String.format("create table %s (c0 FLOAT, c1 STRING)", targetTableFullName),
+        foreachResult(rs_ -> {}));
 
     String temporaryTableName = generateTemporaryTableName();
     String temporaryTableFullName =
-            String.format("\"%s\".\"%s\".\"%s\"", TEST_SNOWFLAKE_DB, TEST_SNOWFLAKE_SCHEMA, temporaryTableName);
+        String.format(
+            "\"%s\".\"%s\".\"%s\"", TEST_SNOWFLAKE_DB, TEST_SNOWFLAKE_SCHEMA, temporaryTableName);
     runQuery(
-            String.format("create table %s (c0 FLOAT, c1 STRING)", temporaryTableFullName),
-            foreachResult(rs_ -> {})
-    );
+        String.format("create table %s (c0 FLOAT, c1 STRING)", temporaryTableFullName),
+        foreachResult(rs_ -> {}));
 
     final ConfigSource config =
-            CONFIG_MAPPER_FACTORY
-                    .newConfigSource()
-                    .set("type", "snowflake")
-                    .set("user", TEST_SNOWFLAKE_USER)
-                    .set("password", TEST_SNOWFLAKE_PASSWORD)
-                    .set("host", TEST_SNOWFLAKE_HOST)
-                    .set("database", TEST_SNOWFLAKE_DB)
-                    .set("warehouse", TEST_SNOWFLAKE_WAREHOUSE)
-                    .set("schema", TEST_SNOWFLAKE_SCHEMA)
-                    .set("mode", "replace")
-                    .set("table", targetTableName)
-            ;
+        CONFIG_MAPPER_FACTORY
+            .newConfigSource()
+            .set("type", "snowflake")
+            .set("user", TEST_SNOWFLAKE_USER)
+            .set("password", TEST_SNOWFLAKE_PASSWORD)
+            .set("host", TEST_SNOWFLAKE_HOST)
+            .set("database", TEST_SNOWFLAKE_DB)
+            .set("warehouse", TEST_SNOWFLAKE_WAREHOUSE)
+            .set("schema", TEST_SNOWFLAKE_SCHEMA)
+            .set("mode", "replace")
+            .set("table", targetTableName);
     embulk.runOutput(config, in.toPath());
 
     config.set("table", temporaryTableName);
     embulk.runOutput(config, in.toPath());
 
     runUpdateQuery(
-            String.format(
-                    "insert into %s select * from %s; drop table %s;",
-                    targetTableFullName,
-                    temporaryTableFullName,
-                    temporaryTableFullName
-            )
-    );
+        String.format(
+            "insert into %s select * from %s; drop table %s;",
+            targetTableFullName, temporaryTableFullName, temporaryTableFullName));
 
     runQuery(
-            String.format(
-                    "select count(*) from %s;",
-                    targetTableFullName
-            ),
-            foreachResult(rs -> {
+        String.format("select count(*) from %s;", targetTableFullName),
+        foreachResult(
+            rs -> {
               assertEquals(6, rs.getInt(1));
-            })
-    );
+            }));
   }
 
   @Test

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -318,17 +318,19 @@ public class TestSnowflakeOutputPlugin {
             .set("schema", TEST_SNOWFLAKE_SCHEMA)
             .set("mode", "replace")
             .set("table", temporaryTableName)
-            .set("after_load",
-                    String.format("insert into \"%s\" select * from \"%s\"; drop table \"%s\";",
-                            targetTableName, temporaryTableName, temporaryTableName));
+            .set(
+                "after_load",
+                String.format(
+                    "insert into \"%s\" select * from \"%s\"; drop table \"%s\";",
+                    targetTableName, temporaryTableName, temporaryTableName));
     embulk.runOutput(config, in.toPath());
 
     runQuery(
-            String.format("select count(*) from %s;", targetTableFullName),
-            foreachResult(
-                    rs -> {
-                      assertEquals(3, rs.getInt(1));
-                    }));
+        String.format("select count(*) from %s;", targetTableFullName),
+        foreachResult(
+            rs -> {
+              assertEquals(3, rs.getInt(1));
+            }));
   }
 
   @Test

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -101,6 +101,7 @@ public class TestSnowflakeOutputPlugin {
     props.setProperty("warehouse", TEST_SNOWFLAKE_WAREHOUSE);
     props.setProperty("db", TEST_SNOWFLAKE_DB);
     props.setProperty("schema", TEST_SNOWFLAKE_SCHEMA);
+    props.setProperty("MULTI_STATEMENT_COUNT", "0");
     TEST_PROPERTIES = props;
   }
 

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -288,6 +288,60 @@ public class TestSnowflakeOutputPlugin {
   }
 
   @Test
+  public void testExecuteMultiQuery() throws IOException {
+    File in = testFolder.newFile(SnowflakeUtils.randomString(8) + ".csv");
+    List<String> lines =
+            Stream.of("c0:double, c1:string", "0.0,aaa", "0.1,bbb", "1.2,ccc")
+                    .collect(Collectors.toList());
+    Files.write(in.toPath(), lines);
+
+    String targetTableName = generateTemporaryTableName();
+    String targetTableFullName =
+            String.format("\"%s\".\"%s\".\"%s\"", TEST_SNOWFLAKE_DB, TEST_SNOWFLAKE_SCHEMA, targetTableName);
+    runQuery(
+            String.format("create table %s (c0 FLOAT, c1 STRING)", targetTableFullName),
+            foreachResult(rs_ -> {})
+    );
+
+    String temporaryTableName = generateTemporaryTableName();
+    String temporaryTableFullName =
+            String.format("\"%s\".\"%s\".\"%s\"", TEST_SNOWFLAKE_DB, TEST_SNOWFLAKE_SCHEMA, temporaryTableName);
+    runQuery(
+            String.format("create table %s (c0 FLOAT, c1 STRING)", temporaryTableFullName),
+            foreachResult(rs_ -> {})
+    );
+
+    final ConfigSource config =
+            CONFIG_MAPPER_FACTORY
+                    .newConfigSource()
+                    .set("type", "snowflake")
+                    .set("user", TEST_SNOWFLAKE_USER)
+                    .set("password", TEST_SNOWFLAKE_PASSWORD)
+                    .set("host", TEST_SNOWFLAKE_HOST)
+                    .set("database", TEST_SNOWFLAKE_DB)
+                    .set("warehouse", TEST_SNOWFLAKE_WAREHOUSE)
+                    .set("schema", TEST_SNOWFLAKE_SCHEMA)
+                    .set("mode", "replace")
+                    .set("table", targetTableName)
+                    .set("MULTI_STATEMENT_COUNT", "0")
+            ;
+    embulk.runOutput(config, in.toPath());
+
+    config.set("table", temporaryTableName);
+    embulk.runOutput(config, in.toPath());
+
+    runQuery(
+            String.format(
+                    "insert into %s SELECT * FROM %s; DROP TABLE %s;",
+                    targetTableFullName,
+                    temporaryTableFullName,
+                    temporaryTableFullName
+            ),
+            foreachResult(rs_ -> {})
+    );
+  }
+
+  @Test
   public void testRuntimeInsertStringTable() throws IOException {
     File in = testFolder.newFile(SnowflakeUtils.randomString(8) + ".csv");
     List<String> lines =


### PR DESCRIPTION
# 概要
- after_loadなどの1文で複数のクエリを指定するためにsnowflakeに対して設定を行いました