### PR TITLE
fix oom in large file input

### DIFF
--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -30,12 +30,10 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   private SnowflakeOutputConnection connection = null;
   private TableIdentifier tableIdentifier = null;
   protected File currentFile;
-
-  private int batchWeight;
-
   protected BufferedWriter writer;
   protected int index;
   protected int batchRows;
+  private int batchWeight;
   private long totalRows;
   private int fileCount;
   private List<Future<Void>> uploadAndCopyFutures;


### PR DESCRIPTION
## Problem
If a large file is provided, this plugin stores all data until it finishes reading input data because flushing data does not happen.  This behavior is caused by incorrect counting batch size. 

## Solution
Count data size by adding data every time not using the size of the intermediate file for transfer. This approach is the same as mysql output plugin.   


