### PR TITLE
Grant permissions to `GITHUB_TOKEN` to publish packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,6 +14,9 @@ on:
 jobs:
   main:
     runs-on: ubuntu-latest
+    permissions:
+      packages: write
+      contents: read
 
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
To publish packages, grant permissions to `GITHUB_TOKEN`.

- packages: write
- contents: read

ref: https://github.com/trocco-io/embulk-output-snowflake/actions/runs/5143327826/jobs/9258195033