### PR TITLE
fix lint

### DIFF
--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -8,12 +8,12 @@ import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
 import org.embulk.config.TaskSource;
 import org.embulk.output.jdbc.*;
+import org.embulk.output.snowflake.PrivateKeyReader;
 import org.embulk.output.snowflake.SnowflakeCopyBatchInsert;
 import org.embulk.output.snowflake.SnowflakeOutputConnection;
 import org.embulk.output.snowflake.SnowflakeOutputConnector;
 import org.embulk.output.snowflake.StageIdentifier;
 import org.embulk.output.snowflake.StageIdentifierHolder;
-import org.embulk.output.snowflake.PrivateKeyReader;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.OutputPlugin;
@@ -104,7 +104,8 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
       try {
         props.put("privateKey", PrivateKeyReader.get(t.getPrivateKey()));
       } catch (IOException e) {
-        // Because the source of newConnection definition does not assume IOException, change it to ConfigException.
+        // Because the source of newConnection definition does not assume IOException, change it to
+        // ConfigException.
         throw new ConfigException(e);
       }
     }

--- a/src/main/java/org/embulk/output/snowflake/PrivateKeyReader.java
+++ b/src/main/java/org/embulk/output/snowflake/PrivateKeyReader.java
@@ -1,32 +1,31 @@
 package org.embulk.output.snowflake;
 
+import java.io.IOException;
+import java.io.StringReader;
+import java.security.PrivateKey;
+import java.security.Security;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.asn1.pkcs.PrivateKeyInfo;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.jce.provider.BouncyCastleProvider;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.openssl.PEMParser;
 import net.snowflake.client.jdbc.internal.org.bouncycastle.openssl.jcajce.JcaPEMKeyConverter;
 
-import java.io.IOException;
-import java.io.StringReader;
-import java.security.PrivateKey;
-import java.security.Security;
+// ref:
+// https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-configure#privatekey-property-in-connection-properties
+public class PrivateKeyReader {
+  public static PrivateKey get(String pemString) throws IOException {
+    Security.addProvider(new BouncyCastleProvider());
+    PEMParser pemParser = new PEMParser(new StringReader(pemString));
+    Object pemObject = pemParser.readObject();
+    pemParser.close();
 
-// ref: https://docs.snowflake.com/en/developer-guide/jdbc/jdbc-configure#privatekey-property-in-connection-properties
-public class PrivateKeyReader
-{
-    public static PrivateKey get(String pemString) throws IOException {
-        Security.addProvider(new BouncyCastleProvider());
-        PEMParser pemParser = new PEMParser(new StringReader(pemString));
-        Object pemObject = pemParser.readObject();
-        pemParser.close();
-
-        PrivateKeyInfo privateKeyInfo;
-        if (pemObject instanceof PrivateKeyInfo) {
-            privateKeyInfo = (PrivateKeyInfo) pemObject;
-        } else {
-            throw new IllegalArgumentException("Provided PEM does not contain a valid Private Key");
-        }
-        JcaPEMKeyConverter converter = new JcaPEMKeyConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME);
-        return converter.getPrivateKey(privateKeyInfo);
+    PrivateKeyInfo privateKeyInfo;
+    if (pemObject instanceof PrivateKeyInfo) {
+      privateKeyInfo = (PrivateKeyInfo) pemObject;
+    } else {
+      throw new IllegalArgumentException("Provided PEM does not contain a valid Private Key");
     }
-
+    JcaPEMKeyConverter converter =
+        new JcaPEMKeyConverter().setProvider(BouncyCastleProvider.PROVIDER_NAME);
+    return converter.getPrivateKey(privateKeyInfo);
+  }
 }


### PR DESCRIPTION
As the title says

### Reasons for Not Testing Connections Using a Private Key

The reason I do not perform connection tests using a private key is that the properties accepted by DriverManager are limited to string-to-string mappings, and thus it cannot accommodate data types such as PrivateKey. 