### PR TITLE
Add `role` to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Snowflake output plugin for Embulk loads records to Snowflake.
 - **database**: destination database name (string, required)
 - **schema**: destination schema name (string, default: "public")
 - **table**: destination table name (string, required)
+- **role**: role to execute queries (string, default: "")
 - **retry_limit**: max retry count for database operations (integer, default: 12). When intermediate table to create already created by another process, this plugin will retry with another table name to avoid collision.
 - **retry_wait**: initial retry wait time in milliseconds (integer, default: 1000 (1 second))
 - **max_retry_wait**: upper limit of retry wait, which will be doubled at every retry (integer, default: 1800000 (30 minutes))

--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -117,7 +117,7 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     props.setProperty("warehouse", t.getWarehouse());
     props.setProperty("db", t.getDatabase());
     props.setProperty("schema", t.getSchema());
-    if(!t.getRole().isEmpty()) {
+    if (!t.getRole().isEmpty()) {
       props.setProperty("role", t.getRole());
     }
 

--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -54,6 +54,10 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     @ConfigDefault("\"public\"")
     public String getSchema();
 
+    @Config("role")
+    @ConfigDefault("\"\"")
+    public String getRole();
+
     @Config("delete_stage")
     @ConfigDefault("false")
     public boolean getDeleteStage();
@@ -113,6 +117,9 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     props.setProperty("warehouse", t.getWarehouse());
     props.setProperty("db", t.getDatabase());
     props.setProperty("schema", t.getSchema());
+    if(!t.getRole().isEmpty()) {
+      props.setProperty("role", t.getRole());
+    }
 
     // When CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX is false (default),
     // getMetaData().getColumns() returns columns of the tables which table name is

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -208,6 +208,7 @@ public class TestSnowflakeOutputPlugin {
     assertEquals("", task.getUser());
     assertEquals("", task.getPassword());
     assertEquals("public", task.getSchema());
+    assertEquals("", task.getRole());
     assertEquals(false, task.getDeleteStage());
   }
 


### PR DESCRIPTION
Hi, I've added a new field, `role`, to the `SnowflakePluginTask`. This enhancement allows users to specify the role for executing queries with this plugin.

resolve #68 

