### PR TITLE
Delete tmp stage even on error and Add delete_stage_on_error option

### DIFF
--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -167,22 +167,6 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
   }
 
   @Override
-  protected void doCommit(JdbcOutputConnection con, PluginTask task, int taskCount)
-      throws SQLException {
-    super.doCommit(con, task, taskCount);
-    SnowflakeOutputConnection snowflakeCon = (SnowflakeOutputConnection) con;
-
-    SnowflakePluginTask t = (SnowflakePluginTask) task;
-    if (this.stageIdentifier == null) {
-      this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(t);
-    }
-
-    if (t.getDeleteStage()) {
-      snowflakeCon.runDropStage(this.stageIdentifier);
-    }
-  }
-
-  @Override
   protected void doBegin(
       JdbcOutputConnection con, PluginTask task, final Schema schema, int taskCount)
       throws SQLException {
@@ -196,16 +180,8 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
       throw new UnsupportedOperationException(
           "Snowflake output plugin doesn't support 'merge_direct' mode.");
     }
-
-    SnowflakePluginTask t = (SnowflakePluginTask) task;
-    // TODO: put some where executes once
-    if (this.stageIdentifier == null) {
-      SnowflakeOutputConnection snowflakeCon =
-          (SnowflakeOutputConnection) getConnector(task, true).connect(true);
-      this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(t);
-      snowflakeCon.runCreateStage(this.stageIdentifier);
-    }
     SnowflakePluginTask pluginTask = (SnowflakePluginTask) task;
+    this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(pluginTask);
 
     return new SnowflakeCopyBatchInsert(
         getConnector(task, true),

--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -147,9 +147,11 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
       snowflakeCon = (SnowflakeOutputConnection) getConnector(task, true).connect(true);
       snowflakeCon.runCreateStage(this.stageIdentifier);
       configDiff = super.transaction(config, schema, taskCount, control);
-      snowflakeCon.runDropStage(this.stageIdentifier);
+      if (t.getDeleteStage()) {
+        snowflakeCon.runDropStage(this.stageIdentifier);
+      }
     } catch (Exception e) {
-      if (t.getDeleteStageOnError()) {
+      if (t.getDeleteStage() && t.getDeleteStageOnError()) {
         try {
           snowflakeCon.runDropStage(this.stageIdentifier);
         } catch (SQLException ex) {

--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -131,33 +131,31 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
   }
 
   @Override
-  public ConfigDiff transaction(ConfigSource config,
-          Schema schema, int taskCount,
-          OutputPlugin.Control control)
-  {
-      PluginTask task = CONFIG_MAPPER.map(config, this.getTaskClass());
-      SnowflakePluginTask t = (SnowflakePluginTask) task;
-      this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(t);
-      ConfigDiff configDiff;
-      SnowflakeOutputConnection snowflakeCon = null;
+  public ConfigDiff transaction(
+      ConfigSource config, Schema schema, int taskCount, OutputPlugin.Control control) {
+    PluginTask task = CONFIG_MAPPER.map(config, this.getTaskClass());
+    SnowflakePluginTask t = (SnowflakePluginTask) task;
+    this.stageIdentifier = StageIdentifierHolder.getStageIdentifier(t);
+    ConfigDiff configDiff;
+    SnowflakeOutputConnection snowflakeCon = null;
 
-      try {
-        snowflakeCon = (SnowflakeOutputConnection) getConnector(task, true).connect(true);
-        snowflakeCon.runCreateStage(this.stageIdentifier);
-        configDiff = super.transaction(config, schema, taskCount, control);
-      }  catch (SQLException ex) {
-        throw new RuntimeException(ex);
-      }  finally {
-        if (t.getDeleteStage()) {
-          try {
-            snowflakeCon.runDropStage(this.stageIdentifier);
-          }  catch (SQLException ex) {
-            throw new RuntimeException(ex);
-          }
+    try {
+      snowflakeCon = (SnowflakeOutputConnection) getConnector(task, true).connect(true);
+      snowflakeCon.runCreateStage(this.stageIdentifier);
+      configDiff = super.transaction(config, schema, taskCount, control);
+    } catch (SQLException ex) {
+      throw new RuntimeException(ex);
+    } finally {
+      if (t.getDeleteStage()) {
+        try {
+          snowflakeCon.runDropStage(this.stageIdentifier);
+        } catch (SQLException ex) {
+          throw new RuntimeException(ex);
         }
       }
+    }
 
-      return configDiff;
+    return configDiff;
   }
 
   @Override

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -61,7 +61,6 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   @Override
   public void prepare(TableIdentifier loadTable, JdbcSchema insertSchema) throws SQLException {
     this.connection = (SnowflakeOutputConnection) connector.connect(true);
-    this.connection.runCreateStage(stageIdentifier);
     this.tableIdentifier = loadTable;
   }
 

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeOutputConnection.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeOutputConnection.java
@@ -11,8 +11,12 @@ import org.embulk.output.jdbc.JdbcOutputConnection;
 import org.embulk.output.jdbc.JdbcSchema;
 import org.embulk.output.jdbc.MergeConfig;
 import org.embulk.output.jdbc.TableIdentifier;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class SnowflakeOutputConnection extends JdbcOutputConnection {
+  private final Logger logger = LoggerFactory.getLogger(SnowflakeOutputConnection.class);
+
   public SnowflakeOutputConnection(Connection connection) throws SQLException {
     super(connection, null);
   }
@@ -32,11 +36,13 @@ public class SnowflakeOutputConnection extends JdbcOutputConnection {
   public void runCreateStage(StageIdentifier stageIdentifier) throws SQLException {
     String sql = buildCreateStageSQL(stageIdentifier);
     runUpdate(sql);
+    logger.info("SQL: {}", sql);
   }
 
   public void runDropStage(StageIdentifier stageIdentifier) throws SQLException {
     String sql = buildDropStageSQL(stageIdentifier);
     runUpdate(sql);
+    logger.info("SQL: {}", sql);
   }
 
   public void runUploadFile(


### PR DESCRIPTION
# What to do

- Modifying policies
    - Both runDropStage and runCreateStage must be executed on same level of the job process.
    - `CREATE STAGE IF NOT EXIST` clause was executed for the number of threads because the execution point of runCreateStage was the multi-threaded startup part of a split job to begin with. However in the case of runDropStage, if the preceding thread deleted the snowflake temp stage, the subsequent threads would fail. So, create and drop should be completed in the OutputPlugin's transaction method, which can encompass the entire job multi-threading processes. 
- Remove existing unnecessary create and drop processes for snowflake temp stage.
- Add drop_stage_on_error option. Both delete_stage and delete_stage_on_error option are effective.

# Issue / Reference

- ref: https://github.com/primenumber-dev/n-transfer-ui/issues/19356



