### PR TITLE
make runnable ci for outside collaborators

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -10,10 +10,15 @@ on:
     branches:
       - 'main'
     types: [opened, synchronize]
+  pull_request_target:
+    branches:
+      - 'main'
+    types: [labeled]
 
 jobs:
   main:
     runs-on: ubuntu-latest
+    if: ${{ github.event_name == 'pull_request' || (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'safe to test'))  }}
     permissions:
       packages: write
       contents: read


### PR DESCRIPTION
run actions in the base branch context when labeled `safe to test`