### PR TITLE
fix: reconnect when auth error occurs in runDropStage method

### DIFF
--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -215,12 +215,12 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
       snowflakeCon.runCreateStage(stageIdentifier);
       configDiff = super.transaction(config, schema, taskCount, control);
       if (t.getDeleteStage()) {
-        runDropStage(snowflakeCon, stageIdentifier, task);
+        runDropStageWithRecovery(snowflakeCon, stageIdentifier, task);
       }
     } catch (Exception e) {
       if (t.getDeleteStage() && t.getDeleteStageOnError()) {
         try {
-          runDropStage(snowflakeCon, stageIdentifier, task);
+          runDropStageWithRecovery(snowflakeCon, stageIdentifier, task);
         } catch (SQLException ex) {
           throw new RuntimeException(ex);
         }
@@ -231,7 +231,7 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     return configDiff;
   }
 
-  private void runDropStage(
+  private void runDropStageWithRecovery(
       SnowflakeOutputConnection snowflakeCon, StageIdentifier stageIdentifier, PluginTask task)
       throws SQLException {
     try {

--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -125,6 +125,16 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     }
   }
 
+  // error codes which need reauthenticate
+  // ref:
+  // https://github.com/snowflakedb/snowflake-jdbc/blob/v3.13.26/src/main/java/net/snowflake/client/jdbc/SnowflakeUtil.java#L42
+  private static final int ID_TOKEN_EXPIRED_GS_CODE = 390110;
+  private static final int SESSION_NOT_EXIST_GS_CODE = 390111;
+  private static final int MASTER_TOKEN_NOTFOUND = 390113;
+  private static final int MASTER_EXPIRED_GS_CODE = 390114;
+  private static final int MASTER_TOKEN_INVALID_GS_CODE = 390115;
+  private static final int ID_TOKEN_INVALID_LOGIN_REQUEST_GS_CODE = 390195;
+
   @Override
   protected Class<? extends PluginTask> getTaskClass() {
     return SnowflakePluginTask.class;
@@ -227,17 +237,25 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     try {
       snowflakeCon.runDropStage(stageIdentifier);
     } catch (SnowflakeSQLException ex) {
-      logger.info("SnowflakeSQLException was caught: {}", ex.getMessage());
+      // INFO: Don't handle only SnowflakeReauthenticationRequest here
+      //       because SnowflakeSQLException with following error codes may be thrown in some cases.
 
-      if (ex.getMessage().startsWith("Authentication token has expired.")
-          || ex.getMessage().startsWith("Session no longer exists.")) {
+      logger.info("SnowflakeSQLException was caught: ({}) {}", ex.getErrorCode(), ex.getMessage());
 
-        // INFO: If runCreateStage consumed a lot of time, authentication might be expired.
-        //       In this case, retry to drop stage.
-        snowflakeCon = (SnowflakeOutputConnection) getConnector(task, true).connect(true);
-        snowflakeCon.runDropStage(stageIdentifier);
-      } else {
-        throw ex;
+      switch (ex.getErrorCode()) {
+        case ID_TOKEN_EXPIRED_GS_CODE:
+        case SESSION_NOT_EXIST_GS_CODE:
+        case MASTER_TOKEN_NOTFOUND:
+        case MASTER_EXPIRED_GS_CODE:
+        case MASTER_TOKEN_INVALID_GS_CODE:
+        case ID_TOKEN_INVALID_LOGIN_REQUEST_GS_CODE:
+          // INFO: If runCreateStage consumed a lot of time, authentication might be expired.
+          //       In this case, retry to drop stage.
+          snowflakeCon = (SnowflakeOutputConnection) getConnector(task, true).connect(true);
+          snowflakeCon.runDropStage(stageIdentifier);
+          break;
+        default:
+          throw ex;
       }
     }
   }


### PR DESCRIPTION
If runCreateStage spent over 4 hours, auth might be expired.