### PR TITLE
add treat_decimal_as_int parameter to set JDBC_TREAT_DECIMAL_AS_INT property of snowflake-jdbc

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ Snowflake output plugin for Embulk loads records to Snowflake.
   - **timezone**: If input column type (embulk type) is timestamp, this plugin needs to format the timestamp value into a SQL string. In this cases, this timezone option is used to control the timezone. (string, value of default_timezone option is used by default)
 - **before_load**: if set, this SQL will be executed before loading all records. In truncate_insert mode, the SQL will be executed after truncating. replace mode doesn't support this option.
 - **after_load**: if set, this SQL will be executed after loading all records.
+- **treat_decimal_as_int**: If set to true, this plugin treats NUMBER columns as BigInt columns. If false, it treats as BigDecimal. (boolean, default: true)
 
 ### Modes
 

--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -86,6 +86,10 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     @ConfigDefault("\"none\"")
     public MatchByColumnName getMatchByColumnName();
 
+    @Config("treat_decimal_as_int")
+    @ConfigDefault("true")
+    public boolean getTreatDecimalAsInt();
+
     public void setCopyIntoTableColumnNames(String[] columnNames);
 
     public String[] getCopyIntoTableColumnNames();
@@ -182,6 +186,8 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     // https://github.com/snowflakedb/snowflake-jdbc/blob/032bdceb408ebeedb1a9ad4edd9ee6cf7c6bb470/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java#L1261-L1269
     props.setProperty("CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX", "true");
     props.setProperty("MULTI_STATEMENT_COUNT", "0");
+
+    props.setProperty("JDBC_TREAT_DECIMAL_AS_INT", t.getTreatDecimalAsInt() ? "true" : "false");
 
     props.putAll(t.getOptions());
 

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -1,6 +1,7 @@
 package org.embulk.output.snowflake;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
@@ -209,7 +210,8 @@ public class TestSnowflakeOutputPlugin {
     assertEquals("", task.getPassword());
     assertEquals("public", task.getSchema());
     assertEquals("", task.getRole());
-    assertEquals(false, task.getDeleteStage());
+    assertFalse(task.getDeleteStage());
+    assertTrue(task.getTreatDecimalAsInt());
   }
 
   @Test


### PR DESCRIPTION
As defalt, snowflake-jdbc treats NUMBER type as BigInt.
If JDBC_TREAT_DECIMAL_AS_INT is set to false, it treats NUMBER type as BigDecimal.

see also : https://github.com/snowflakedb/snowflake-jdbc/issues/154
