### PR TITLE
docs: Add delete_stage option to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Snowflake output plugin for Embulk loads records to Snowflake.
   - **timezone**: If input column type (embulk type) is timestamp, this plugin needs to format the timestamp value into a SQL string. In this cases, this timezone option is used to control the timezone. (string, value of default_timezone option is used by default)
 - **before_load**: if set, this SQL will be executed before loading all records. In truncate_insert mode, the SQL will be executed after truncating. replace mode doesn't support this option.
 - **after_load**: if set, this SQL will be executed after loading all records.
+- **delete_stage**: if true, deletes the stage created during execution (boolean, default: false)
 
 ### Modes
 


### PR DESCRIPTION
# Overview
Added description for the `delete_stage` option in the README.

# Background
When the number of stages created on Snowflake exceeds 10,000, the results of `SHOW STAGES` query start getting truncated.

Additionally, the [Terraform Snowflake Provider](https://github.com/snowflakedb/terraform-provider-snowflake) uses `SHOW STAGES` to retrieve resource states, which means commands like `terraform plan` may stop working properly when this truncation occurs.

The `delete_stage` option is an effective countermeasure for this issue, and it's considered an important option that many users should be aware of.