### PR TITLE
Add jdbc_tracing configuration option to control Snowflake JDBC driver logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Snowflake output plugin for Embulk loads records to Snowflake.
 - **max_retry_wait**: upper limit of retry wait, which will be doubled at every retry (integer, default: 1800000 (30 minutes))
 - **max_upload_retries**: maximum number of retries for file upload to Snowflake (integer, default: 3).
 - **max_copy_retries**: maximum number of retries for COPY operations in Snowflake (integer, default: 3). Retries occur when transient errors such as communication failures happen during the COPY process.
+- **jdbc_tracing**: JDBC driver logging level. This controls the verbosity of Snowflake JDBC driver logs. Valid values are: OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL (string, default: "INFO").
 - **mode**: "insert", "insert_direct", "truncate_insert", "replace" or "merge". See below. (string, required)
 - **merge_keys**: key column names for merging records in merge mode (string array, required in merge mode if table doesn't have primary key)
 - **merge_rule**: list of column assignments for updating existing records used in merge mode, for example `"foo" = T."foo" + S."foo"` (`T` means target table and `S` means source table). (string array, default: always overwrites with new values)

--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -91,6 +91,10 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     @ConfigDefault("\"none\"")
     public MatchByColumnName getMatchByColumnName();
 
+    @Config("jdbc_tracing")
+    @ConfigDefault("\"INFO\"")
+    public String getJdbcTracing();
+
     public void setCopyIntoTableColumnNames(String[] columnNames);
 
     public String[] getCopyIntoTableColumnNames();
@@ -197,6 +201,8 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     // https://github.com/snowflakedb/snowflake-jdbc/blob/032bdceb408ebeedb1a9ad4edd9ee6cf7c6bb470/src/main/java/net/snowflake/client/jdbc/SnowflakeDatabaseMetaData.java#L1261-L1269
     props.setProperty("CLIENT_METADATA_REQUEST_USE_CONNECTION_CTX", "true");
     props.setProperty("MULTI_STATEMENT_COUNT", "0");
+
+    props.setProperty("tracing", t.getJdbcTracing());
 
     props.putAll(t.getOptions());
 


### PR DESCRIPTION
## Summary

This PR adds a new `jdbc_tracing` configuration option that allows users to control the verbosity of Snowflake JDBC driver logs. This enhancement provides better debugging capabilities and allows users to reduce log noise in production environments.

### Changes Made

- **Configuration Option**: Added `jdbc_tracing` parameter with default value "INFO"
- **Valid Values**: OFF, SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST, ALL
- **Implementation**: The option is passed directly to the Snowflake JDBC driver via the "tracing" property
- **Documentation**: Updated README.md with comprehensive description of the new parameter

### Why This Is Useful

- **Debugging**: Developers can increase logging verbosity (e.g., FINE, FINER, FINEST) to troubleshoot connection issues, query performance, or other JDBC-related problems
- **Production Optimization**: Users can reduce log verbosity (e.g., WARNING, SEVERE) to minimize log output in production environments
- **Flexibility**: Provides granular control over JDBC driver logging without requiring code changes

### Technical Details

The configuration is implemented by setting the `tracing` property on the JDBC connection properties, which is a standard Snowflake JDBC driver feature. The default value "INFO" maintains backward compatibility with existing behavior.

## Test Plan

- [ ] Verify the configuration option is properly parsed and applied to JDBC connections
- [ ] Test with different logging levels (OFF, INFO, FINE, ALL) to confirm they affect log output appropriately
- [ ] Ensure backward compatibility by testing without the new parameter (should default to "INFO")
- [ ] Validate that invalid values are handled gracefully by the JDBC driver
- [ ] Test in both development and production-like environments to verify log behavior

🤖 Generated with [Claude Code](https://claude.ai/code)