### PR TITLE
Add escape_with_enclosing option for correct newline handling

### DIFF
--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -87,6 +87,10 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     @ConfigDefault("false")
     public boolean getDeleteStageOnError();
 
+    @Config("escape_with_enclosing")
+    @ConfigDefault("false")
+    public boolean getEscapeWithEnclosing();
+
     @Config("match_by_column_name")
     @ConfigDefault("\"none\"")
     public MatchByColumnName getMatchByColumnName();
@@ -332,7 +336,8 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
         false,
         pluginTask.getMaxUploadRetries(),
         pluginTask.getMaxCopyRetries(),
-        pluginTask.getEmtpyFieldAsNull());
+        pluginTask.getEmtpyFieldAsNull(),
+        pluginTask.getEscapeWithEnclosing());
   }
 
   @Override

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -281,7 +281,6 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     for (char c : v.toCharArray()) {
       writer.write(escape(c));
     }
-    nextColumn(v.length() * 2 + 4);
   }
 
   // Enclose field with double quotes. Inside the quotes:

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -45,6 +45,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   private List<Future<Void>> uploadFutures;
   private List<String> uploadedFileNames;
   private boolean emptyFieldAsNull;
+  private final boolean escapeWithEnclosing;
 
   private String[] copyIntoTableColumnNames;
 
@@ -58,7 +59,8 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
       boolean deleteStageFile,
       int maxUploadRetries,
       int maxCopyRetries,
-      boolean emptyFieldAsNull)
+      boolean emptyFieldAsNull,
+      boolean escapeWithEnclosing)
       throws IOException {
     this.index = 0;
     openNewFile();
@@ -73,6 +75,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     this.maxUploadRetries = maxUploadRetries;
     this.maxCopyRetries = maxCopyRetries;
     this.emptyFieldAsNull = emptyFieldAsNull;
+    this.escapeWithEnclosing = escapeWithEnclosing;
   }
 
   @Override
@@ -182,19 +185,32 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
 
   public void setString(String v) throws IOException {
     appendDelimiter();
-    setEscapedString(v);
+    if (escapeWithEnclosing) {
+      setEnclosedString(v);
+    } else {
+      setEscapedString(v);
+    }
     nextColumn(v.length() * 2 + 4);
   }
 
   public void setNString(String v) throws IOException {
     appendDelimiter();
-    setEscapedString(v);
+    if (escapeWithEnclosing) {
+      setEnclosedString(v);
+    } else {
+      setEscapedString(v);
+    }
     nextColumn(v.length() * 2 + 4);
   }
 
   public void setBytes(byte[] v) throws IOException {
     appendDelimiter();
-    setEscapedString(String.valueOf(v));
+    String s = String.valueOf(v);
+    if (escapeWithEnclosing) {
+      setEnclosedString(s);
+    } else {
+      setEscapedString(s);
+    }
     nextColumn(v.length + 4);
   }
 
@@ -266,6 +282,22 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
       writer.write(escape(c));
     }
     nextColumn(v.length() * 2 + 4);
+  }
+
+  // Enclose field with double quotes. Inside the quotes:
+  // - " is escaped as "" (CSV standard)
+  // - \0 (null byte) is removed
+  // - All other characters (\n, \t, \r, \\) are written as-is
+  private void setEnclosedString(String v) throws IOException {
+    writer.write('"');
+    for (char c : v.toCharArray()) {
+      if (c == '"') {
+        writer.write("\"\"");
+      } else if (c != 0) {
+        writer.write(c);
+      }
+    }
+    writer.write('"');
   }
 
   @Override
@@ -383,7 +415,8 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
                 copyIntoTableColumnNames,
                 copyIntoCSVColumnNumbers,
                 delimiterString,
-                emptyFieldAsNull);
+                emptyFieldAsNull,
+                escapeWithEnclosing);
 
             double seconds = (System.currentTimeMillis() - startTime) / 1000.0;
             logger.info(

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -278,8 +278,9 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   }
 
   private void setEscapedString(String v) throws IOException {
-    for (char c : v.toCharArray()) {
-      writer.write(escape(c));
+    int len = v.length();
+    for (int i = 0; i < len; i++) {
+      writer.write(escape(v.charAt(i)));
     }
   }
 
@@ -289,7 +290,9 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   // - All other characters (\n, \t, \r, \\) are written as-is
   private void setEnclosedString(String v) throws IOException {
     writer.write('"');
-    for (char c : v.toCharArray()) {
+    int len = v.length();
+    for (int i = 0; i < len; i++) {
+      char c = v.charAt(i);
       if (c == '"') {
         writer.write("\"\"");
       } else if (c != 0) {

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeOutputConnection.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeOutputConnection.java
@@ -170,7 +170,8 @@ public class SnowflakeOutputConnection extends JdbcOutputConnection {
       String[] tableColumnNames,
       int[] csvColumnNumbers,
       String delimiterString,
-      boolean emptyFieldAsNull)
+      boolean emptyFieldAsNull,
+      boolean escapeWithEnclosing)
       throws SQLException {
     String sql =
         tableColumnNames != null && tableColumnNames.length > 0
@@ -181,9 +182,15 @@ public class SnowflakeOutputConnection extends JdbcOutputConnection {
                 tableColumnNames,
                 csvColumnNumbers,
                 delimiterString,
-                emptyFieldAsNull)
+                emptyFieldAsNull,
+                escapeWithEnclosing)
             : buildBatchCopySQL(
-                tableIdentifier, stageIdentifier, fileNames, delimiterString, emptyFieldAsNull);
+                tableIdentifier,
+                stageIdentifier,
+                fileNames,
+                delimiterString,
+                emptyFieldAsNull,
+                escapeWithEnclosing);
 
     runUpdate(sql);
   }
@@ -193,7 +200,8 @@ public class SnowflakeOutputConnection extends JdbcOutputConnection {
       StageIdentifier stageIdentifier,
       List<String> fileNames,
       String delimiterString,
-      boolean emptyFieldAsNull) {
+      boolean emptyFieldAsNull,
+      boolean escapeWithEnclosing) {
     StringBuilder sb = new StringBuilder();
     sb.append("COPY INTO ");
     quoteTableIdentifier(sb, tableIdentifier);
@@ -207,6 +215,13 @@ public class SnowflakeOutputConnection extends JdbcOutputConnection {
     if (!emptyFieldAsNull) {
       sb.append(" EMPTY_FIELD_AS_NULL = FALSE");
     }
+    if (escapeWithEnclosing) {
+      sb.append(" FIELD_OPTIONALLY_ENCLOSED_BY = '\"'");
+      // Disable backslash escape interpretation for unenclosed fields (e.g. boolean, numeric).
+      // The default ESCAPE_UNENCLOSED_FIELD is '\\', which could cause Snowflake to
+      // misinterpret backslashes in unenclosed fields as escape characters.
+      sb.append(" ESCAPE_UNENCLOSED_FIELD = NONE");
+    }
     sb.append(" );");
     return sb.toString();
   }
@@ -218,7 +233,8 @@ public class SnowflakeOutputConnection extends JdbcOutputConnection {
       String[] tableColumnNames,
       int[] csvColumnNumbers,
       String delimiterString,
-      boolean emptyFieldAsNull) {
+      boolean emptyFieldAsNull,
+      boolean escapeWithEnclosing) {
     StringBuilder sb = new StringBuilder();
     sb.append("COPY INTO ");
     quoteTableIdentifier(sb, tableIdentifier);
@@ -247,6 +263,13 @@ public class SnowflakeOutputConnection extends JdbcOutputConnection {
     sb.append("'");
     if (!emptyFieldAsNull) {
       sb.append(" EMPTY_FIELD_AS_NULL = FALSE");
+    }
+    if (escapeWithEnclosing) {
+      sb.append(" FIELD_OPTIONALLY_ENCLOSED_BY = '\"'");
+      // Disable backslash escape interpretation for unenclosed fields (e.g. boolean, numeric).
+      // The default ESCAPE_UNENCLOSED_FIELD is '\\', which could cause Snowflake to
+      // misinterpret backslashes in unenclosed fields as escape characters.
+      sb.append(" ESCAPE_UNENCLOSED_FIELD = NONE");
     }
     sb.append(" );");
     return sb.toString();

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeCopyBatchInsert.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeCopyBatchInsert.java
@@ -1,0 +1,228 @@
+package org.embulk.output.snowflake;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.*;
+import java.util.zip.GZIPInputStream;
+import org.junit.Test;
+
+public class TestSnowflakeCopyBatchInsert {
+
+  private SnowflakeCopyBatchInsert createBatchInsert(boolean escapeWithEnclosing) throws Exception {
+    return new SnowflakeCopyBatchInsert(
+        null, null, new String[0], new int[0], false, 3, 3, true, escapeWithEnclosing);
+  }
+
+  private String readGzipFile(File file) throws Exception {
+    try (GZIPInputStream gis = new GZIPInputStream(new FileInputStream(file));
+        InputStreamReader reader = new InputStreamReader(gis, "UTF-8");
+        BufferedReader br = new BufferedReader(reader)) {
+      StringBuilder sb = new StringBuilder();
+      char[] buf = new char[1024];
+      int len;
+      while ((len = br.read(buf)) != -1) {
+        sb.append(buf, 0, len);
+      }
+      return sb.toString();
+    }
+  }
+
+  // escape() tests (existing backslash escape behavior)
+
+  @Test
+  public void testEscapeBackslash() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    assertEquals("\\\\", batch.escape('\\'));
+    batch.close();
+  }
+
+  @Test
+  public void testEscapeNewline() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    assertEquals("\\n", batch.escape('\n'));
+    batch.close();
+  }
+
+  @Test
+  public void testEscapeTab() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    assertEquals("\\t", batch.escape('\t'));
+    batch.close();
+  }
+
+  @Test
+  public void testEscapeCarriageReturn() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    assertEquals("\\r", batch.escape('\r'));
+    batch.close();
+  }
+
+  @Test
+  public void testEscapeNullByte() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    assertEquals("", batch.escape('\0'));
+    batch.close();
+  }
+
+  @Test
+  public void testEscapeRegularChar() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    assertEquals("a", batch.escape('a'));
+    batch.close();
+  }
+
+  @Test
+  public void testEscapeDoubleQuoteNotEscaped() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    assertEquals("\"", batch.escape('"'));
+    batch.close();
+  }
+
+  // setString() without enclosing (existing behavior)
+
+  @Test
+  public void testSetStringWithoutEnclosing() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    batch.setString("hello\tworld\n");
+    batch.add();
+
+    File file = batch.currentFile;
+    batch.writer.close();
+
+    String content = readGzipFile(file);
+    assertEquals("hello\\tworld\\n\n", content);
+    file.delete();
+  }
+
+  // setString() with enclosing (new behavior)
+
+  @Test
+  public void testSetStringWithEnclosing() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(true);
+    batch.setString("hello\tworld\n");
+    batch.add();
+
+    File file = batch.currentFile;
+    batch.writer.close();
+
+    String content = readGzipFile(file);
+    assertEquals("\"hello\tworld\n\"\n", content);
+    file.delete();
+  }
+
+  @Test
+  public void testEnclosingEscapesDoubleQuotes() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(true);
+    batch.setString("say \"hello\"");
+    batch.add();
+
+    File file = batch.currentFile;
+    batch.writer.close();
+
+    String content = readGzipFile(file);
+    assertEquals("\"say \"\"hello\"\"\"\n", content);
+    file.delete();
+  }
+
+  @Test
+  public void testEnclosingRemovesNullByte() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(true);
+    batch.setString("hello\0world");
+    batch.add();
+
+    File file = batch.currentFile;
+    batch.writer.close();
+
+    String content = readGzipFile(file);
+    assertEquals("\"helloworld\"\n", content);
+    file.delete();
+  }
+
+  @Test
+  public void testEnclosingPreservesBackslash() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(true);
+    batch.setString("path\\to\\file");
+    batch.add();
+
+    File file = batch.currentFile;
+    batch.writer.close();
+
+    String content = readGzipFile(file);
+    assertEquals("\"path\\to\\file\"\n", content);
+    file.delete();
+  }
+
+  @Test
+  public void testEnclosingPreservesCarriageReturn() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(true);
+    batch.setString("line1\r\nline2");
+    batch.add();
+
+    File file = batch.currentFile;
+    batch.writer.close();
+
+    String content = readGzipFile(file);
+    assertEquals("\"line1\r\nline2\"\n", content);
+    file.delete();
+  }
+
+  @Test
+  public void testMultipleColumnsWithEnclosing() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(true);
+    batch.setString("col1\nvalue");
+    batch.setString("col2\tvalue");
+    batch.add();
+
+    File file = batch.currentFile;
+    batch.writer.close();
+
+    String content = readGzipFile(file);
+    assertEquals("\"col1\nvalue\"\t\"col2\tvalue\"\n", content);
+    file.delete();
+  }
+
+  @Test
+  public void testMultipleColumnsWithoutEnclosing() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    batch.setString("col1\nvalue");
+    batch.setString("col2\tvalue");
+    batch.add();
+
+    File file = batch.currentFile;
+    batch.writer.close();
+
+    String content = readGzipFile(file);
+    assertEquals("col1\\nvalue\tcol2\\tvalue\n", content);
+    file.delete();
+  }
+
+  @Test
+  public void testEmptyStringWithEnclosing() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(true);
+    batch.setString("");
+    batch.add();
+
+    File file = batch.currentFile;
+    batch.writer.close();
+
+    String content = readGzipFile(file);
+    assertEquals("\"\"\n", content);
+    file.delete();
+  }
+
+  @Test
+  public void testNonStringColumnsNotEnclosed() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(true);
+    batch.setBoolean(true);
+    batch.setLong(42L);
+    batch.setString("text\n");
+    batch.add();
+
+    File file = batch.currentFile;
+    batch.writer.close();
+
+    String content = readGzipFile(file);
+    assertEquals("true\t42\t\"text\n\"\n", content);
+    file.delete();
+  }
+}

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeOutputPlugin.java
@@ -219,6 +219,7 @@ public class TestSnowflakeOutputPlugin {
     assertEquals("public", task.getSchema());
     assertEquals("", task.getRole());
     assertEquals(false, task.getDeleteStage());
+    assertEquals(false, task.getEscapeWithEnclosing());
   }
 
   @Test


### PR DESCRIPTION
## Summary

- Add `escape_with_enclosing` boolean option (default: `false`) to enclose string fields with double quotes instead of backslash escaping
- When enabled, `COPY INTO` uses `FIELD_OPTIONALLY_ENCLOSED_BY = '"'` and `ESCAPE_UNENCLOSED_FIELD = NONE`
- Fixes the issue where newline characters (`\n`) in data are stored as literal `\n` strings in Snowflake instead of actual newlines

### Background

The current backslash escape converts `\n` (0x0A) to literal `\n` (0x5C + 0x6E) in the TSV file. However, Snowflake's default `ESCAPE_UNENCLOSED_FIELD` expects `\` + actual newline byte, not `\` + `n`. As a result, the literal string `\n` is loaded into Snowflake as-is.

The new enclosing mode wraps string fields in `"`, allowing Snowflake to correctly distinguish data newlines from record delimiters.

### Changes

| File | Change |
|---|---|
| `SnowflakeOutputPlugin.java` | Add `escape_with_enclosing` config option |
| `SnowflakeCopyBatchInsert.java` | Add `setEnclosedString()` with `"` enclosing and `""` escaping for quotes |
| `SnowflakeOutputConnection.java` | Add `FIELD_OPTIONALLY_ENCLOSED_BY` and `ESCAPE_UNENCLOSED_FIELD = NONE` to `COPY INTO` SQL |
| `TestSnowflakeCopyBatchInsert.java` | 17 unit tests covering both escape modes |

### Usage

```yaml
out:
  type: snowflake
  escape_with_enclosing: true  # default: false
```

## Test plan

- [x] Unit tests for existing backslash escape behavior (unchanged)
- [x] Unit tests for new enclosing mode (double quote wrapping, `""` escaping, null byte removal, backslash/CR preservation)
- [x] Unit test for mixed column types (boolean/long not enclosed, string enclosed)
- [ ] Integration test with Snowflake: verify `\n` in data loads as actual newline when enabled
- [ ] Integration test: verify existing behavior unchanged when disabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)