### PR TITLE
Restore nextColumn in setEscapedString and setEnclosedString

### DIFF
--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -301,6 +301,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
       }
     }
     writer.write('"');
+    nextColumn(v.length() * 2 + 4);
   }
 
   @Override

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -282,6 +282,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     for (int i = 0; i < len; i++) {
       writer.write(escape(v.charAt(i)));
     }
+    nextColumn(v.length() * 2 + 4);
   }
 
   // Enclose field with double quotes. Inside the quotes:


### PR DESCRIPTION
## Summary

- Restore `nextColumn()` call in `setEscapedString()` that was removed in #88, to maintain the previous flush frequency
- Add the same `nextColumn()` call in `setEnclosedString()` for consistent behavior when `escape_with_enclosing` is enabled

## Background

PR #88 removed the `nextColumn()` call in `setEscapedString()` as a bug fix for double counting. However, this halved the flush frequency, which can cause OOM under memory-constrained environments. This change restores the previous flush behavior as a temporary workaround until the `batch_size` default is properly adjusted.

## Test plan

- [ ] Verify flush frequency matches pre-#88 behavior
- [ ] Confirm no OOM under memory-constrained environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)