### PR TITLE
Pipeline upload and batch COPY INTO using CompletionService

### DIFF
--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -19,7 +19,8 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   private final Logger logger = LoggerFactory.getLogger(SnowflakeCopyBatchInsert.class);
   private final JdbcOutputConnector connector;
   protected static final Charset FILE_CHARSET = Charset.forName("UTF-8");
-  private final ExecutorService executorService;
+  private final ExecutorService uploadExecutorService;
+  private final ExecutorService copyExecutorService;
   private final StageIdentifier stageIdentifier;
   private final boolean deleteStageFile;
 
@@ -27,8 +28,9 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   protected static final String newLineString = "\n";
   protected static final String delimiterString = "\t";
   // https://docs.snowflake.com/en/sql-reference/sql/copy-into-table
-  // Number of files per chunk for pipelining upload and batch COPY.
-  // When a chunk fills up, batch COPY is submitted asynchronously while uploads continue.
+  // Number of completed uploads to accumulate before submitting a batch COPY.
+  // Batching is based on upload completion order (not submission order) to avoid
+  // stalling on slow uploads within a chunk.
   private static final int BATCH_COPY_CHUNK_SIZE = 20;
   private static final int MAX_DELETE_RETRIES = 3;
   private final int maxUploadRetries;
@@ -43,12 +45,13 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   private int batchWeight;
   private long totalRows;
   private int fileCount;
-  // Upload and batch COPY are pipelined in chunks of BATCH_COPY_CHUNK_SIZE.
-  // When a chunk fills up, its uploads and file names are captured into a BatchCopyTask
-  // (submitted to executorService), and these two lists are reset for the next chunk.
-  private List<Future<Void>> currentChunkUploadFutures;
-  private List<String> currentChunkFileNames;
-  // Tracks submitted BatchCopyTask futures so finish() can wait for all pipelined COPYs.
+  // CompletionService wraps the upload executor to allow polling uploads by completion order.
+  private final ExecutorCompletionService<String> uploadCompletionService;
+  // Number of uploads submitted but not yet drained from uploadCompletionService.
+  private int pendingUploads;
+  // File names of completed uploads ready to be included in the next batch COPY.
+  private final List<String> readyForCopyFileNames;
+  // Tracks submitted batch COPY futures so finish() can wait for all pipelined COPYs.
   private final List<Future<Void>> copyFutures;
   // Accumulates all file names across chunks for stage file cleanup in finish().
   private final List<String> allUploadedFileNames;
@@ -76,10 +79,14 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     this.stageIdentifier = stageIdentifier;
     this.copyIntoTableColumnNames = copyIntoTableColumnNames;
     this.copyIntoCSVColumnNumbers = copyIntoCSVColumnNumbers;
-    this.executorService = Executors.newCachedThreadPool();
+    this.uploadExecutorService = Executors.newCachedThreadPool();
+    // Single-thread executor for COPY: limits to 1 concurrent COPY per task to avoid
+    // connection explosion, while keeping the main thread free to continue reading data.
+    this.copyExecutorService = Executors.newSingleThreadExecutor();
+    this.uploadCompletionService = new ExecutorCompletionService<>(uploadExecutorService);
     this.deleteStageFile = deleteStageFile;
-    this.currentChunkUploadFutures = new ArrayList<>();
-    this.currentChunkFileNames = new ArrayList<>();
+    this.pendingUploads = 0;
+    this.readyForCopyFileNames = new ArrayList<>();
     this.copyFutures = new ArrayList<>();
     this.allUploadedFileNames = new ArrayList<>();
     this.maxUploadRetries = maxUploadRetries;
@@ -329,28 +336,54 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
 
     UploadTask uploadTask =
         new UploadTask(file, batchRows, stageIdentifier, snowflakeStageFileName, maxUploadRetries);
-    currentChunkUploadFutures.add(executorService.submit(uploadTask));
-    currentChunkFileNames.add(snowflakeStageFileName + ".csv.gz");
+    uploadCompletionService.submit(uploadTask);
+    pendingUploads++;
 
     fileCount++;
     totalRows += batchRows;
     batchRows = 0;
     batchWeight = 0;
 
-    // Submit batch COPY when chunk reaches threshold
-    if (currentChunkFileNames.size() >= BATCH_COPY_CHUNK_SIZE) {
-      submitBatchCopyForCurrentChunk();
-    }
+    drainCompletedUploads();
+    submitBatchCopyIfReady();
 
     openNewFile();
   }
 
+  private void drainCompletedUploads() throws SQLException {
+    Future<String> completed;
+    while ((completed = uploadCompletionService.poll()) != null) {
+      readyForCopyFileNames.add(getOrUnwrap(completed));
+      pendingUploads--;
+    }
+  }
+
+  private void submitBatchCopyIfReady() {
+    while (readyForCopyFileNames.size() >= BATCH_COPY_CHUNK_SIZE) {
+      List<String> batch =
+          new ArrayList<>(readyForCopyFileNames.subList(0, BATCH_COPY_CHUNK_SIZE));
+      readyForCopyFileNames.subList(0, BATCH_COPY_CHUNK_SIZE).clear();
+
+      allUploadedFileNames.addAll(batch);
+
+      copyFutures.add(
+          copyExecutorService.submit(
+              () -> {
+                runBatchCopyWithRetry(batch);
+                return null;
+              }));
+    }
+  }
+
   public void close() throws IOException, SQLException {
-    executorService.shutdownNow();
+    uploadExecutorService.shutdownNow();
+    copyExecutorService.shutdownNow();
 
     try {
-      executorService.awaitTermination(60, TimeUnit.SECONDS);
+      uploadExecutorService.awaitTermination(60, TimeUnit.SECONDS);
+      copyExecutorService.awaitTermination(60, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
     }
 
     closeCurrentFile().delete();
@@ -360,55 +393,32 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     }
   }
 
-  private void submitBatchCopyForCurrentChunk() {
-    // Capture current chunk data
-    List<Future<Void>> chunkUploadFutures = currentChunkUploadFutures;
-    List<String> chunkFileNames = new ArrayList<>(currentChunkFileNames);
-
-    // Submit BatchCopyTask — upload wait happens inside the task
-    copyFutures.add(
-        executorService.submit(
-            () -> {
-              waitForFutures(chunkUploadFutures);
-              runBatchCopyWithRetry(chunkFileNames);
-              return null;
-            }));
-
-    // Track all file names for delete
-    allUploadedFileNames.addAll(currentChunkFileNames);
-
-    // Reset for next chunk
-    currentChunkUploadFutures = new ArrayList<>();
-    currentChunkFileNames = new ArrayList<>();
-  }
-
-  private void waitForFutures(List<Future<Void>> futures) throws SQLException {
-    for (Future<Void> future : futures) {
-      try {
-        future.get();
-      } catch (InterruptedException e) {
-        throw new RuntimeException(e);
-      } catch (ExecutionException e) {
-        if (e.getCause() instanceof SQLException) {
-          throw (SQLException) e.getCause();
-        }
-        throw new RuntimeException(e);
-      }
-    }
-  }
-
   @Override
   public void finish() throws IOException, SQLException {
     try {
-      // Handle remaining chunk (below threshold)
-      if (!currentChunkFileNames.isEmpty()) {
-        waitForFutures(currentChunkUploadFutures);
-        allUploadedFileNames.addAll(currentChunkFileNames);
-        runBatchCopyWithRetry(currentChunkFileNames);
+      while (pendingUploads > 0) {
+        try {
+          readyForCopyFileNames.add(getOrUnwrap(uploadCompletionService.take()));
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(e);
+        }
+        pendingUploads--;
       }
 
-      // Wait for all previously submitted batch COPY tasks
-      waitForFutures(copyFutures);
+      // Submit batch COPY for any full chunks among remaining completed uploads
+      submitBatchCopyIfReady();
+
+      // Run final batch COPY for remaining files (below threshold) synchronously
+      if (!readyForCopyFileNames.isEmpty()) {
+        allUploadedFileNames.addAll(readyForCopyFileNames);
+        runBatchCopyWithRetry(readyForCopyFileNames);
+      }
+
+      for (Future<Void> future : copyFutures) {
+        getOrUnwrap(future);
+      }
+      copyFutures.clear();
 
       if (!allUploadedFileNames.isEmpty()) {
         logger.info("Loaded {} files.", fileCount);
@@ -418,6 +428,20 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
       if (deleteStageFile && !allUploadedFileNames.isEmpty()) {
         deleteStageFiles(allUploadedFileNames);
       }
+    }
+  }
+
+  private <T> T getOrUnwrap(Future<T> future) throws SQLException {
+    try {
+      return future.get();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new RuntimeException(e);
+    } catch (ExecutionException e) {
+      if (e.getCause() instanceof SQLException) {
+        throw (SQLException) e.getCause();
+      }
+      throw new RuntimeException(e);
     }
   }
 
@@ -537,7 +561,11 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     }
   }
 
-  private class UploadTask implements Callable<Void> {
+  /**
+   * Upload task that returns the staged file name (with .csv.gz extension) on completion. Used with
+   * ExecutorCompletionService to allow batch COPY to be triggered by upload completion order.
+   */
+  private class UploadTask implements Callable<String> {
     private final File file;
     private final int batchRows;
     private final String snowflakeStageFileName;
@@ -557,7 +585,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
       this.maxUploadRetries = maxUploadRetries;
     }
 
-    public Void call() throws SQLException {
+    public String call() throws SQLException {
       try {
         long startTime = System.currentTimeMillis();
         retryWithBackoff(
@@ -586,7 +614,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
         file.delete();
       }
 
-      return null;
+      return snowflakeStageFileName + ".csv.gz";
     }
   }
 }

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -27,8 +27,9 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   protected static final String newLineString = "\n";
   protected static final String delimiterString = "\t";
   // https://docs.snowflake.com/en/sql-reference/sql/copy-into-table
-  // "The maximum number of files names that can be specified is 1000."
-  private static final int MAX_FILES_PER_COPY = 1000;
+  // Number of files per chunk for pipelining upload and batch COPY.
+  // When a chunk fills up, batch COPY is submitted asynchronously while uploads continue.
+  private static final int BATCH_COPY_CHUNK_SIZE = 20;
   private static final int MAX_DELETE_RETRIES = 3;
   private final int maxUploadRetries;
   private final int maxCopyRetries;
@@ -42,8 +43,15 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   private int batchWeight;
   private long totalRows;
   private int fileCount;
-  private List<Future<Void>> uploadFutures;
-  private List<String> uploadedFileNames;
+  // Upload and batch COPY are pipelined in chunks of MAX_FILES_PER_COPY.
+  // When a chunk fills up, its uploads and file names are captured into a BatchCopyTask
+  // (submitted to executorService), and these two lists are reset for the next chunk.
+  private List<Future<Void>> currentChunkUploadFutures;
+  private List<String> currentChunkFileNames;
+  // Tracks submitted BatchCopyTask futures so finish() can wait for all pipelined COPYs.
+  private final List<Future<Void>> copyFutures;
+  // Accumulates all file names across chunks for stage file cleanup in finish().
+  private final List<String> allUploadedFileNames;
   private boolean emptyFieldAsNull;
   private final boolean escapeWithEnclosing;
 
@@ -70,8 +78,10 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     this.copyIntoCSVColumnNumbers = copyIntoCSVColumnNumbers;
     this.executorService = Executors.newCachedThreadPool();
     this.deleteStageFile = deleteStageFile;
-    this.uploadFutures = new ArrayList<>();
-    this.uploadedFileNames = Collections.synchronizedList(new ArrayList<>());
+    this.currentChunkUploadFutures = new ArrayList<>();
+    this.currentChunkFileNames = new ArrayList<>();
+    this.copyFutures = new ArrayList<>();
+    this.allUploadedFileNames = new ArrayList<>();
     this.maxUploadRetries = maxUploadRetries;
     this.maxCopyRetries = maxCopyRetries;
     this.emptyFieldAsNull = emptyFieldAsNull;
@@ -319,13 +329,18 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
 
     UploadTask uploadTask =
         new UploadTask(file, batchRows, stageIdentifier, snowflakeStageFileName, maxUploadRetries);
-    uploadFutures.add(executorService.submit(uploadTask));
-    uploadedFileNames.add(snowflakeStageFileName + ".csv.gz");
+    currentChunkUploadFutures.add(executorService.submit(uploadTask));
+    currentChunkFileNames.add(snowflakeStageFileName + ".csv.gz");
 
     fileCount++;
     totalRows += batchRows;
     batchRows = 0;
     batchWeight = 0;
+
+    // Submit batch COPY when chunk reaches threshold
+    if (currentChunkFileNames.size() >= BATCH_COPY_CHUNK_SIZE) {
+      submitBatchCopyForCurrentChunk();
+    }
 
     openNewFile();
   }
@@ -345,12 +360,32 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     }
   }
 
-  @Override
-  public void finish() throws IOException, SQLException {
-    // Wait for all uploads to complete
-    for (Future<Void> uploadFuture : uploadFutures) {
+  private void submitBatchCopyForCurrentChunk() {
+    // Capture current chunk data
+    List<Future<Void>> chunkUploadFutures = currentChunkUploadFutures;
+    List<String> chunkFileNames = new ArrayList<>(currentChunkFileNames);
+
+    // Submit BatchCopyTask — upload wait happens inside the task
+    copyFutures.add(
+        executorService.submit(
+            () -> {
+              waitForFutures(chunkUploadFutures);
+              runBatchCopyWithRetry(chunkFileNames);
+              return null;
+            }));
+
+    // Track all file names for delete
+    allUploadedFileNames.addAll(currentChunkFileNames);
+
+    // Reset for next chunk
+    currentChunkUploadFutures = new ArrayList<>();
+    currentChunkFileNames = new ArrayList<>();
+  }
+
+  private void waitForFutures(List<Future<Void>> futures) throws SQLException {
+    for (Future<Void> future : futures) {
       try {
-        uploadFuture.get();
+        future.get();
       } catch (InterruptedException e) {
         throw new RuntimeException(e);
       } catch (ExecutionException e) {
@@ -360,44 +395,53 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
         throw new RuntimeException(e);
       }
     }
+  }
 
-    if (uploadedFileNames.isEmpty()) {
+  @Override
+  public void finish() throws IOException, SQLException {
+    // Handle remaining chunk (below threshold)
+    if (!currentChunkFileNames.isEmpty()) {
+      waitForFutures(currentChunkUploadFutures);
+      allUploadedFileNames.addAll(currentChunkFileNames);
+      runBatchCopyWithRetry(currentChunkFileNames);
+    }
+
+    // Wait for all previously submitted batch COPY tasks
+    waitForFutures(copyFutures);
+
+    if (allUploadedFileNames.isEmpty()) {
       return;
     }
 
-    // Run batch COPY in chunks of MAX_FILES_PER_COPY
     try {
-      for (int i = 0; i < uploadedFileNames.size(); i += MAX_FILES_PER_COPY) {
-        List<String> chunk =
-            uploadedFileNames.subList(
-                i, Math.min(i + MAX_FILES_PER_COPY, uploadedFileNames.size()));
-        runBatchCopyWithRetry(chunk);
-      }
-
       logger.info("Loaded {} files.", fileCount);
     } finally {
       // Delete stage files if configured — clean up even on partial failure
-      // runDeleteStageFile appends ".csv.gz" internally, so strip it from uploadedFileNames
       if (deleteStageFile) {
-        for (String fileName : uploadedFileNames) {
-          String nameWithoutExtension = fileName.replaceFirst("\\.csv\\.gz$", "");
-          try {
-            // Use a fresh connection per retry — the existing connection may be broken
-            // after a JDBC communication error, so reusing it would fail again.
-            retryWithBackoff(
-                MAX_DELETE_RETRIES,
-                "Delete stage file " + fileName,
-                () -> {
-                  try (SnowflakeOutputConnection con =
-                      (SnowflakeOutputConnection) connector.connect(true)) {
-                    con.runDeleteStageFile(stageIdentifier, nameWithoutExtension);
-                  }
-                  return null;
-                });
-          } catch (SQLException e) {
-            logger.warn("Failed to delete stage file {}: {}", fileName, e.getMessage());
-          }
-        }
+        deleteStageFiles(allUploadedFileNames);
+      }
+    }
+  }
+
+  private void deleteStageFiles(List<String> fileNames) {
+    // runDeleteStageFile appends ".csv.gz" internally, so strip it from file names
+    for (String fileName : fileNames) {
+      String nameWithoutExtension = fileName.replaceFirst("\\.csv\\.gz$", "");
+      try {
+        // Use a fresh connection per retry — the existing connection may be broken
+        // after a JDBC communication error, so reusing it would fail again.
+        retryWithBackoff(
+            MAX_DELETE_RETRIES,
+            "Delete stage file " + fileName,
+            () -> {
+              try (SnowflakeOutputConnection con =
+                  (SnowflakeOutputConnection) connector.connect(true)) {
+                con.runDeleteStageFile(stageIdentifier, nameWithoutExtension);
+              }
+              return null;
+            });
+      } catch (SQLException e) {
+        logger.warn("Failed to delete stage file {}: {}", fileName, e.getMessage());
       }
     }
   }

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -360,8 +360,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
 
   private void submitBatchCopyIfReady() {
     while (readyForCopyFileNames.size() >= BATCH_COPY_CHUNK_SIZE) {
-      List<String> batch =
-          new ArrayList<>(readyForCopyFileNames.subList(0, BATCH_COPY_CHUNK_SIZE));
+      List<String> batch = new ArrayList<>(readyForCopyFileNames.subList(0, BATCH_COPY_CHUNK_SIZE));
       readyForCopyFileNames.subList(0, BATCH_COPY_CHUNK_SIZE).clear();
 
       allUploadedFileNames.addAll(batch);

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -52,7 +52,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   // File names of completed uploads ready to be included in the next batch COPY.
   private final List<String> readyForCopyFileNames;
   // Tracks submitted batch COPY futures so finish() can wait for all pipelined COPYs.
-  private final List<Future<Void>> copyFutures;
+  final List<Future<Void>> copyFutures;
   // Accumulates all file names across chunks for stage file cleanup in finish().
   private final List<String> allUploadedFileNames;
   private boolean emptyFieldAsNull;
@@ -345,6 +345,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     batchWeight = 0;
 
     drainCompletedUploads();
+    checkCompletedCopies();
     submitBatchCopyIfReady();
 
     openNewFile();
@@ -355,6 +356,17 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
     while ((completed = uploadCompletionService.poll()) != null) {
       readyForCopyFileNames.add(getOrUnwrap(completed));
       pendingUploads--;
+    }
+  }
+
+  private void checkCompletedCopies() throws SQLException {
+    Iterator<Future<Void>> it = copyFutures.iterator();
+    while (it.hasNext()) {
+      Future<Void> future = it.next();
+      if (future.isDone()) {
+        getOrUnwrap(future);
+        it.remove();
+      }
     }
   }
 

--- a/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
+++ b/src/main/java/org/embulk/output/snowflake/SnowflakeCopyBatchInsert.java
@@ -43,7 +43,7 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
   private int batchWeight;
   private long totalRows;
   private int fileCount;
-  // Upload and batch COPY are pipelined in chunks of MAX_FILES_PER_COPY.
+  // Upload and batch COPY are pipelined in chunks of BATCH_COPY_CHUNK_SIZE.
   // When a chunk fills up, its uploads and file names are captured into a BatchCopyTask
   // (submitted to executorService), and these two lists are reset for the next chunk.
   private List<Future<Void>> currentChunkUploadFutures;
@@ -399,25 +399,23 @@ public class SnowflakeCopyBatchInsert implements BatchInsert {
 
   @Override
   public void finish() throws IOException, SQLException {
-    // Handle remaining chunk (below threshold)
-    if (!currentChunkFileNames.isEmpty()) {
-      waitForFutures(currentChunkUploadFutures);
-      allUploadedFileNames.addAll(currentChunkFileNames);
-      runBatchCopyWithRetry(currentChunkFileNames);
-    }
-
-    // Wait for all previously submitted batch COPY tasks
-    waitForFutures(copyFutures);
-
-    if (allUploadedFileNames.isEmpty()) {
-      return;
-    }
-
     try {
-      logger.info("Loaded {} files.", fileCount);
+      // Handle remaining chunk (below threshold)
+      if (!currentChunkFileNames.isEmpty()) {
+        waitForFutures(currentChunkUploadFutures);
+        allUploadedFileNames.addAll(currentChunkFileNames);
+        runBatchCopyWithRetry(currentChunkFileNames);
+      }
+
+      // Wait for all previously submitted batch COPY tasks
+      waitForFutures(copyFutures);
+
+      if (!allUploadedFileNames.isEmpty()) {
+        logger.info("Loaded {} files.", fileCount);
+      }
     } finally {
       // Delete stage files if configured — clean up even on partial failure
-      if (deleteStageFile) {
+      if (deleteStageFile && !allUploadedFileNames.isEmpty()) {
         deleteStageFiles(allUploadedFileNames);
       }
     }

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeCopyBatchInsert.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeCopyBatchInsert.java
@@ -18,8 +18,8 @@ public class TestSnowflakeCopyBatchInsert {
         null, null, new String[0], new int[0], false, 3, 3, true, escapeWithEnclosing);
   }
 
-  private SnowflakeCopyBatchInsert createBatchInsertWithConnector(
-      JdbcOutputConnector connector) throws Exception {
+  private SnowflakeCopyBatchInsert createBatchInsertWithConnector(JdbcOutputConnector connector)
+      throws Exception {
     return new SnowflakeCopyBatchInsert(
         connector, null, new String[0], new int[0], false, 0, 0, true, false);
   }
@@ -249,9 +249,10 @@ public class TestSnowflakeCopyBatchInsert {
   @Test
   public void testFlushFailsFastOnUploadError() throws Exception {
     // Connector that always throws on connect — upload will fail
-    JdbcOutputConnector failingConnector = autoCommit -> {
-      throw new SQLException("Connection refused");
-    };
+    JdbcOutputConnector failingConnector =
+        autoCommit -> {
+          throw new SQLException("Connection refused");
+        };
 
     SnowflakeCopyBatchInsert batch = createBatchInsertWithConnector(failingConnector);
     try {
@@ -273,9 +274,10 @@ public class TestSnowflakeCopyBatchInsert {
 
   @Test
   public void testFinishDetectsUploadError() throws Exception {
-    JdbcOutputConnector failingConnector = autoCommit -> {
-      throw new SQLException("Upload failed");
-    };
+    JdbcOutputConnector failingConnector =
+        autoCommit -> {
+          throw new SQLException("Upload failed");
+        };
 
     SnowflakeCopyBatchInsert batch = createBatchInsertWithConnector(failingConnector);
     try {

--- a/src/test/java/org/embulk/output/snowflake/TestSnowflakeCopyBatchInsert.java
+++ b/src/test/java/org/embulk/output/snowflake/TestSnowflakeCopyBatchInsert.java
@@ -1,9 +1,14 @@
 package org.embulk.output.snowflake;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.*;
+import java.sql.SQLException;
+import java.util.concurrent.*;
 import java.util.zip.GZIPInputStream;
+import org.embulk.output.jdbc.JdbcOutputConnector;
 import org.junit.Test;
 
 public class TestSnowflakeCopyBatchInsert {
@@ -11,6 +16,12 @@ public class TestSnowflakeCopyBatchInsert {
   private SnowflakeCopyBatchInsert createBatchInsert(boolean escapeWithEnclosing) throws Exception {
     return new SnowflakeCopyBatchInsert(
         null, null, new String[0], new int[0], false, 3, 3, true, escapeWithEnclosing);
+  }
+
+  private SnowflakeCopyBatchInsert createBatchInsertWithConnector(
+      JdbcOutputConnector connector) throws Exception {
+    return new SnowflakeCopyBatchInsert(
+        connector, null, new String[0], new int[0], false, 0, 0, true, false);
   }
 
   private String readGzipFile(File file) throws Exception {
@@ -25,6 +36,13 @@ public class TestSnowflakeCopyBatchInsert {
       }
       return sb.toString();
     }
+  }
+
+  /** Write enough data to trigger flush(). */
+  private void writeRowAndFlush(SnowflakeCopyBatchInsert batch) throws Exception {
+    batch.setString("value");
+    batch.add();
+    batch.flush();
   }
 
   // escape() tests (existing backslash escape behavior)
@@ -224,5 +242,113 @@ public class TestSnowflakeCopyBatchInsert {
     String content = readGzipFile(file);
     assertEquals("true\t42\t\"text\n\"\n", content);
     file.delete();
+  }
+
+  // Pipeline fail-fast tests
+
+  @Test
+  public void testFlushFailsFastOnUploadError() throws Exception {
+    // Connector that always throws on connect — upload will fail
+    JdbcOutputConnector failingConnector = autoCommit -> {
+      throw new SQLException("Connection refused");
+    };
+
+    SnowflakeCopyBatchInsert batch = createBatchInsertWithConnector(failingConnector);
+    try {
+      // First flush submits an upload that will fail
+      writeRowAndFlush(batch);
+      // Give the upload thread time to fail
+      Thread.sleep(500);
+      // Second flush should detect the upload failure via drainCompletedUploads()
+      try {
+        writeRowAndFlush(batch);
+        fail("Expected SQLException from failed upload");
+      } catch (SQLException e) {
+        assertTrue(e.getMessage().contains("Connection refused"));
+      }
+    } finally {
+      batch.close();
+    }
+  }
+
+  @Test
+  public void testFinishDetectsUploadError() throws Exception {
+    JdbcOutputConnector failingConnector = autoCommit -> {
+      throw new SQLException("Upload failed");
+    };
+
+    SnowflakeCopyBatchInsert batch = createBatchInsertWithConnector(failingConnector);
+    try {
+      writeRowAndFlush(batch);
+      try {
+        batch.finish();
+        fail("Expected SQLException from failed upload");
+      } catch (SQLException e) {
+        assertTrue(e.getMessage().contains("Upload failed"));
+      }
+    } finally {
+      batch.close();
+    }
+  }
+
+  @Test
+  public void testEmptyBatchSkipsUpload() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    // flush with no rows written — should skip upload
+    batch.flush();
+    // Should not throw; no upload was submitted
+    batch.close();
+  }
+
+  @Test
+  public void testFlushFailsFastOnCopyError() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    // Inject a failed COPY future directly into copyFutures
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<Void> failedFuture =
+        executor.submit(
+            () -> {
+              throw new SQLException("COPY failed: table not found");
+            });
+    // Wait for the future to complete (with error)
+    Thread.sleep(100);
+    batch.copyFutures.add(failedFuture);
+    executor.shutdown();
+
+    try {
+      // flush() should detect the failed COPY via checkCompletedCopies()
+      writeRowAndFlush(batch);
+      fail("Expected SQLException from failed COPY");
+    } catch (SQLException e) {
+      assertTrue(e.getMessage().contains("COPY failed"));
+    } finally {
+      batch.close();
+    }
+  }
+
+  @Test
+  public void testFinishFailsOnCopyError() throws Exception {
+    SnowflakeCopyBatchInsert batch = createBatchInsert(false);
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<Void> failedFuture =
+        executor.submit(
+            () -> {
+              throw new SQLException("COPY failed: permission denied");
+            });
+    Thread.sleep(100);
+    batch.copyFutures.add(failedFuture);
+    executor.shutdown();
+
+    try {
+      batch.finish();
+      fail("Expected exception from failed COPY");
+    } catch (SQLException e) {
+      assertTrue(e.getMessage().contains("COPY failed"));
+    } catch (RuntimeException e) {
+      assertTrue(e.getCause() instanceof SQLException);
+      assertTrue(e.getCause().getMessage().contains("COPY failed"));
+    } finally {
+      batch.close();
+    }
   }
 }


### PR DESCRIPTION
## Summary

Optimize the upload → COPY INTO pipeline by switching from submission-order chunking to **completion-order batching** using `ExecutorCompletionService`.

## Background

PR #88 introduced batch COPY INTO (`FILES` parameter) to reduce COPY statement count. However, it required all uploads to complete before any COPY could start (upload and COPY were fully serial). This PR restores pipeline parallelism while keeping batch COPY.

## Architecture

### Before (0.8.6): Upload and COPY fully serial

```
Main thread:  [flush₁] [flush₂] ... [flush₃₂₀]
Upload pool:  [upload₁ upload₂ ... upload₃₂₀] ──wait──▶
COPY:                                                    [batch COPY (all 320 files)]
              ├──── upload phase (no COPY) ────┤├── COPY phase (no upload) ──┤
```

### After (this PR): Upload and COPY pipelined by completion order

```
Main thread:  [flush₁] [flush₂] ... [flush₃₂₀]  (never blocked)
Upload pool:  [upload₁ upload₂ ... ───────────────────────────────▶
COPY thread:        [batch COPY 20 files] [batch COPY 20 files] [...] ──▶
              ├───── upload and COPY overlap continuously ─────────┤
```

Key: COPY is triggered when **20 uploads complete** (not when 20 are submitted), so slow uploads don't stall the batch.

## How it works

1. **`ExecutorCompletionService<String>`** wraps the upload executor. Each `UploadTask` returns the staged file name on completion.
2. **`drainCompletedUploads()`** (called in `flush()`) polls completed uploads non-blocking and collects file names.
3. When **20 file names accumulate**, a batch COPY is submitted to a **dedicated single-thread executor** (`copyExecutorService`).
4. The single-thread COPY executor serializes COPY operations per task (1 COPY at a time), preventing connection explosion while keeping the main thread free.
5. **`finish()`** drains remaining uploads (blocking), runs a final COPY for the tail chunk, then waits for all pipelined COPYs.

## Why a dedicated COPY executor?

Using the same `CachedThreadPool` for both uploads and COPYs caused thread/connection explosion (observed in benchmarking: 19min vs 11min baseline). The `newSingleThreadExecutor` limits to 1 concurrent COPY per task (4 total across embulk tasks), matching the connection profile of the previous implementation.

## Changes

- `UploadTask`: `Callable<Void>` → `Callable<String>` (returns staged file name)
- New: `uploadCompletionService` (`ExecutorCompletionService`) for completion-order polling
- New: `copyExecutorService` (`newSingleThreadExecutor`) for dedicated COPY execution
- New: `drainCompletedUploads()` — non-blocking poll of completed uploads
- New: `submitBatchCopyIfReady()` — submits batch COPY when threshold reached
- New: `getOrUnwrap()` — generic Future exception unwrapping helper (deduplicated from 3 call sites)
- `close()`: shuts down both executors, restores interrupt flag

## Benchmark results

**Condition**: Local 1.6GB CSV (15M rows), `batch_size: 5MB`, ~320 files/task, 5 runs each

| Version | Median | Avg | COPY count |
|---|---|---|---|
| 0.8.3 (1 file = 1 COPY) | **5:04** | 4:55 | ~1280 |
| 0.8.6 (all uploads → 1 batch COPY) | **2:17** | 2:33 | ~4 |
| **This PR** (completion-order pipeline) | **1:37** | 1:34 | ~64 |

- **3.1x faster than 0.8.3**: batch COPY eliminates per-file connection overhead
- **1.4x faster than 0.8.6**: pipeline overlap means COPY runs while uploads continue

## Test plan
- [x] Benchmark with batch_size=5MB (320+ files) confirms pipeline effect
- [x] Benchmark with batch_size=512KB (100+ files, small data) confirms batch COPY correctness
- [ ] Files < 20 (below chunk threshold): final COPY in `finish()` handles the tail
- [ ] Upload failure: exception propagates via `getOrUnwrap()` → `drainCompletedUploads()`
- [ ] COPY failure: exception propagates via `getOrUnwrap()` in `finish()`
- [ ] `delete_stage: true`: all uploaded files are cleaned up in `finally` block

---

## 日本語説明

### 概要

Upload → COPY INTO のパイプラインを、提出順チャンクから `ExecutorCompletionService` を使った**完了順バッチ**に変更し、パフォーマンスを改善。

### 背景

PR #88 でバッチ COPY INTO (`FILES` パラメータ) を導入し COPY 文の発行回数を削減した。しかし、全ファイルの Upload 完了まで COPY が始まらない（Upload と COPY が完全直列）という問題があった。本 PR はバッチ COPY を維持しつつ、パイプライン並列性を復活させる。

### アーキテクチャ

**変更前 (0.8.6)**: Upload フェーズ → 全完了待ち → COPY フェーズ（直列）

**変更後 (本 PR)**: Upload 完了順に 20 ファイルずつバッチ COPY を専用スレッドで実行。COPY 実行中も次のファイルの Upload が並行して進む。

### 仕組み

1. `ExecutorCompletionService<String>` で Upload の完了順にファイル名を取得
2. `flush()` 内で `drainCompletedUploads()` を呼び、完了済み Upload をノンブロッキングで回収
3. 20 ファイル蓄積したら、**COPY 専用の単一スレッド executor** にバッチ COPY を submit
4. 単一スレッド executor により 1 タスクあたり同時 1 COPY に制限（コネクション爆発を回避）
5. `finish()` で残りの Upload を待ち、端数チャンクの COPY を実行、パイプライン COPY の完了を待機

### COPY 専用 executor を分離した理由

Upload と COPY を同じ `CachedThreadPool` で実行するとスレッド・コネクション数が爆発し、逆に遅くなることをベンチマークで確認。`newSingleThreadExecutor` で COPY を分離することで、タスクあたり同時 1 COPY に抑制。

### ベンチマーク結果

**条件**: ローカル 1.6GB CSV (1500万行), `batch_size: 5MB`, タスクあたり約320ファイル, 各5回実行

| バージョン | 中央値 | 平均 | COPY 回数 |
|---|---|---|---|
| 0.8.3 (1ファイル=1 COPY) | **5:04** | 4:55 | ~1280 |
| 0.8.6 (全Upload後に一括COPY) | **2:17** | 2:33 | ~4 |
| **本 PR** (完了順パイプライン) | **1:37** | 1:34 | ~64 |

- **0.8.3 の約 3.1 倍速**: バッチ COPY でファイルごとのコネクション確立オーバーヘッドを排除
- **0.8.6 の約 1.4 倍速**: パイプライン化により Upload と COPY が常にオーバーラップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)