### PR TITLE
Add OAuth Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Snowflake output plugin for Embulk loads records to Snowflake.
 - **password**: database login password (string, default: "")
 - **privateKey**: database login using key-pair authentication(string, default: ""). This authentication method requires a 2048-bit (minimum) RSA key pair.
 - **private_key_passphrase**: passphrase for private_key (string, default: "")
+- **token**: OAuth access token for authentication (string, default: ""). When provided, OAuth authentication will be used instead of password or private key authentication.
 - **warehouse**: destination warehouse name (string, required)
 - **database**: destination database name (string, required)
 - **schema**: destination schema name (string, default: "public")

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Snowflake output plugin for Embulk loads records to Snowflake.
 - **password**: database login password (string, default: "")
 - **privateKey**: database login using key-pair authentication(string, default: ""). This authentication method requires a 2048-bit (minimum) RSA key pair.
 - **private_key_passphrase**: passphrase for private_key (string, default: "")
-- **token**: OAuth access token for authentication (string, default: ""). When provided, OAuth authentication will be used instead of password or private key authentication.
+- **token**: OAuth access token for authentication (string, default: ""). OAuth authentication is used only when neither **password** nor **privateKey** is specified; if either of those is set, it takes precedence over **token**.
 - **warehouse**: destination warehouse name (string, required)
 - **database**: destination database name (string, required)
 - **schema**: destination schema name (string, default: "public")

--- a/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
+++ b/src/main/java/org/embulk/output/SnowflakeOutputPlugin.java
@@ -99,6 +99,10 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
     @ConfigDefault("\"INFO\"")
     public String getJdbcTracing();
 
+    @Config("token")
+    @ConfigDefault("\"\"")
+    public String getToken();
+
     public void setCopyIntoTableColumnNames(String[] columnNames);
 
     public String[] getCopyIntoTableColumnNames();
@@ -189,6 +193,9 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
         // wrap it with ConfigException, which is unchecked.
         throw new ConfigException(e);
       }
+    } else if (!t.getToken().isEmpty()) {
+      props.setProperty("authenticator", "oauth");
+      props.setProperty("token", t.getToken());
     }
 
     props.setProperty("warehouse", t.getWarehouse());
@@ -350,6 +357,8 @@ public class SnowflakeOutputPlugin extends AbstractJdbcOutputPlugin {
       } else if (key.equals("proxyPassword")) {
         maskedProps.setProperty(key, "***");
       } else if (key.equals("privateKey")) {
+        maskedProps.setProperty(key, "***");
+      } else if (key.equals("token")) {
         maskedProps.setProperty(key, "***");
       } else {
         maskedProps.setProperty(key, props.getProperty(key));


### PR DESCRIPTION
## Summary
Added support for OAuth authentication (using access tokens) as a method to connect to Snowflake.

## Changes
- Added `token` config option for OAuth access tokens in `SnowflakePluginTask`
- Updated connection properties to set `authenticator=oauth` and `token` when a token is provided
- Added masking for `token` (`***`) in `logConnectionProperties` to prevent log leakage
- Updated `README.md` to document the new `token` configuration parameter

## Impact & Compatibility
- Backward compatible: Existing authentication methods (`password` and `privateKey`) are unaffected when `token` is not specified.

## Verification
- [ ] Verified successful output/ingestion to Snowflake using `token` (OAuth authentication)
- [ ] Confirmed that `token` is properly masked in connection logs
- [ ] Confirmed that traditional authentication methods continue to work when `token` is omitted